### PR TITLE
Fix WireGuard config file import to handle flexible formatting

### DIFF
--- a/package/plugin-gargoyle-wireguard/files/www/js/wireguard.js
+++ b/package/plugin-gargoyle-wireguard/files/www/js/wireguard.js
@@ -1089,38 +1089,50 @@ function parseCfg(cfgdata)
 			}
 		}
 		// Do interface
-		var cfgdataidx = 0;		
+		var cfgdataidx = 0;
 		for(cfgdataidx = interfaceStart+1; cfgdataidx <= interfaceStop; cfgdataidx++)
 		{
-			var lineParts = cfgdata[cfgdataidx].split(" = ");
-			if(lineParts[0] == "Address")
+			var lineParts = cfgdata[cfgdataidx].split("=");
+			if(lineParts.length >= 2)
 			{
-				var subLineParts = lineParts[1].split("/");
-				document.getElementById("wireguard_client_ip").value = subLineParts[0];
-			}
-			else if(lineParts[0] == "PrivateKey")
-			{
-				document.getElementById("wireguard_client_privkey").value = lineParts[1];
-				setPubkeyFromPrivkey(lineParts[1],"wireguard_client_pubkey");
+				var key = lineParts[0].trim();
+				var value = lineParts.slice(1).join("=").trim();
+
+				if(key == "Address")
+				{
+					var subLineParts = value.split("/");
+					document.getElementById("wireguard_client_ip").value = subLineParts[0];
+				}
+				else if(key == "PrivateKey")
+				{
+					document.getElementById("wireguard_client_privkey").value = value;
+					setPubkeyFromPrivkey(value,"wireguard_client_pubkey");
+				}
 			}
 		}
 		// Do peer (server)
 		for(cfgdataidx = peerStart+1; cfgdataidx <= peerStop; cfgdataidx++)
 		{
-			var lineParts = cfgdata[cfgdataidx].split(" = ");
-			if(lineParts[0] == "AllowedIPs")
+			var lineParts = cfgdata[cfgdataidx].split("=");
+			if(lineParts.length >= 2)
 			{
-				document.getElementById("wireguard_client_allowed_ips").value = lineParts[1];
-			}
-			else if(lineParts[0] == "Endpoint")
-			{
-				var subLineParts = lineParts[1].split(":");
-				document.getElementById("wireguard_client_server_host").value = subLineParts[0];
-				document.getElementById("wireguard_client_server_port").value = subLineParts[1];
-			}
-			else if(lineParts[0] == "PublicKey")
-			{
-				document.getElementById("wireguard_client_server_pubkey").value = lineParts[1];
+				var key = lineParts[0].trim();
+				var value = lineParts.slice(1).join("=").trim();
+
+				if(key == "AllowedIPs")
+				{
+					document.getElementById("wireguard_client_allowed_ips").value = value;
+				}
+				else if(key == "Endpoint")
+				{
+					var subLineParts = value.split(":");
+					document.getElementById("wireguard_client_server_host").value = subLineParts[0];
+					document.getElementById("wireguard_client_server_port").value = subLineParts[1];
+				}
+				else if(key == "PublicKey")
+				{
+					document.getElementById("wireguard_client_server_pubkey").value = value;
+				}
 			}
 		}
 		wireguard_client_config_manual.checked = true;


### PR DESCRIPTION
The config file parser was too strict when parsing uploaded WireGuard configuration files. It required exact formatting with spaces around the equals sign (Key = Value), causing valid config files to be rejected with "Could not understand config file format" error.

Changes:
- Modified parseCfg() function to split on '=' and trim whitespace
- Now handles various formats: Key=Value, Key = Value, Key= Value
- Added check for lineParts.length >= 2 before processing
- Uses slice(1).join("=") to handle edge cases where value contains '='

This fix allows config files generated by Gargoyle or other WireGuard tools to be imported successfully regardless of spacing around delimiters.

Closes #[issue number if applicable]